### PR TITLE
[make drivers use full dependency injection instead of creating their…

### DIFF
--- a/Drivers/DHT22T/Src/dht22.c
+++ b/Drivers/DHT22T/Src/dht22.c
@@ -28,43 +28,6 @@ error_type_t dht22Init(dht22_t *dht22_object)
     {
         return SYSTEM_NULL_PARAMETER;
     }
-
-    if (dht22_object->config.gpio_port == GPIOA)
-    {
-        __HAL_RCC_GPIOA_CLK_ENABLE();
-    }
-    else if (dht22_object->config.gpio_port == GPIOB)
-    {
-        __HAL_RCC_GPIOB_CLK_ENABLE();
-    }
-    else if (dht22_object->config.gpio_port == GPIOC)
-    {
-        __HAL_RCC_GPIOC_CLK_ENABLE();
-    }
-    else if (dht22_object->config.gpio_port == GPIOD)
-    {
-        __HAL_RCC_GPIOD_CLK_ENABLE();
-    }
-    else if (dht22_object->config.gpio_port == GPIOE)
-    {
-        __HAL_RCC_GPIOE_CLK_ENABLE();
-    }
-    else if (dht22_object->config.gpio_port == GPIOH)
-    {
-        __HAL_RCC_GPIOH_CLK_ENABLE();
-    }
-    else
-    {
-        return SYSTEM_INVALID_PIN_PORT;
-    }
-
-    GPIO_InitTypeDef GPIO_InitStruct = {0};
-
-    GPIO_InitStruct.Pin = dht22_object->config.gpio_pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_OD;
-    GPIO_InitStruct.Pull = GPIO_PULLUP;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_MEDIUM;
-    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
     // set pin high as default
     HAL_GPIO_WritePin(dht22_object->config.gpio_port, dht22_object->config.gpio_pin, GPIO_PIN_SET);
     // set pin high as default
@@ -245,7 +208,6 @@ error_type_t dht22DeInit(dht22_t *dht22_object)
 {
     if (dht22_object)
     {
-        HAL_GPIO_DeInit(dht22_object->config.gpio_port, dht22_object->config.gpio_pin);
         dht22_object->initialized = false;
         return SYSTEM_OK;
     }

--- a/Drivers/ESPCHAT/Inc/esp32_chat.h
+++ b/Drivers/ESPCHAT/Inc/esp32_chat.h
@@ -11,18 +11,8 @@ extern "C"
     typedef struct esp32_chat_t esp32_chat_t;
     typedef struct
     {
-        UART_HandleTypeDef *uart_object;
-        USART_TypeDef *instance;
-        uint32_t baud;
-        uint32_t word_length;
-        uint32_t stop_bit;
-        uint32_t parity;
-        uint32_t mode;
-        uint32_t hw_flow_ctrl;
-        uint32_t oversampling;
-
+        UART_HandleTypeDef* uart_object;
     } esp32_chat_config_t;
-    extern esp32_chat_config_t DEFAULT_ESPCHAT_CONFIG;
     esp32_chat_t *esp32ChatCreate(const esp32_chat_config_t *config);
     error_type_t esp32ChatInit(esp32_chat_t *esp32_chat_object);
     error_type_t esp32ChatSendReceive(esp32_chat_t *esp32_chat_object, const char *message, char *response, uint16_t response_size);

--- a/Drivers/ESPCHAT/Src/esp32_chat.c
+++ b/Drivers/ESPCHAT/Src/esp32_chat.c
@@ -5,18 +5,6 @@
 #include <at_commands.h>
 #define SERIAL_SEND_TIMEOUT 100
 
-esp32_chat_config_t DEFAULT_ESPCHAT_CONFIG = {
-    .uart_object = NULL,
-    .instance = USART2,
-    .baud = 115200,
-    .word_length = UART_WORDLENGTH_8B,
-    .stop_bit = UART_STOPBITS_1,
-    .parity = UART_PARITY_NONE,
-    .mode = UART_MODE_TX_RX,
-    .hw_flow_ctrl = UART_HWCONTROL_NONE,
-    .oversampling = UART_OVERSAMPLING_16
-
-};
 struct esp32_chat_t
 {
     UART_HandleTypeDef *uart_object;
@@ -29,11 +17,6 @@ error_type_t esp32ChatInit(esp32_chat_t *esp32_chat_object)
     {
         return SYSTEM_NULL_PARAMETER;
     }
-    if (HAL_UART_Init(esp32_chat_object->uart_object) != HAL_OK)
-    {
-        Error_Handler();
-        return SYSTEM_FAILED;
-    }
     esp32_chat_object->initialized = true;
     return SYSTEM_OK;
 }
@@ -45,14 +28,6 @@ esp32_chat_t *esp32ChatCreate(const esp32_chat_config_t *config)
     }
     esp32_chat_t *esp32_chat_object = (esp32_chat_t *)malloc(sizeof(esp32_chat_t));
     esp32_chat_object->uart_object = config->uart_object;
-    esp32_chat_object->uart_object->Instance = config->instance;
-    esp32_chat_object->uart_object->Init.BaudRate = config->baud;
-    esp32_chat_object->uart_object->Init.WordLength = config->word_length;
-    esp32_chat_object->uart_object->Init.StopBits = config->stop_bit;
-    esp32_chat_object->uart_object->Init.Parity = config->parity;
-    esp32_chat_object->uart_object->Init.Mode = config->mode;
-    esp32_chat_object->uart_object->Init.HwFlowCtl = config->hw_flow_ctrl;
-    esp32_chat_object->uart_object->Init.OverSampling = config->oversampling;
     return esp32_chat_object;
 }
 
@@ -60,9 +35,6 @@ error_type_t esp32ChatDeInit(esp32_chat_t *esp32_chat_object)
 {
     if (esp32_chat_object)
     {
-        HAL_StatusTypeDef err = HAL_UART_DeInit(esp32_chat_object->uart_object->Instance);
-        if (err != HAL_OK)
-            return SYSTEM_FAILED;
         esp32_chat_object->initialized = false;
         return SYSTEM_OK;
     }

--- a/Drivers/ESPCHAT/Src/esp32_chat_example.c
+++ b/Drivers/ESPCHAT/Src/esp32_chat_example.c
@@ -1,7 +1,9 @@
 #include <esp32_chat.h>
 #include <common_headers.h>
-esp32_chat_config_t config = DEFAULT_ESPCHAT_CONFIG;
-config.uart_object = &huart2;
+UART_HandleTypeDef huart2;
+esp32_chat_config_t config = {
+    .uart_object = &huart2
+};
 esp32_chat_t *esp32_chat_object = esp32ChatCreate(&config);
 char *message = "AT\n";
 if (!esp32_chat_object)

--- a/Drivers/SDCard/Inc/sdcard.h
+++ b/Drivers/SDCard/Inc/sdcard.h
@@ -16,9 +16,6 @@ extern "C" {
 typedef struct sdcard_t sdcard_t;
 typedef struct {
     SPI_HandleTypeDef *spi_handle;
-    GPIO_TypeDef *cs_port;
-    uint16_t cs_pin;
-    SPI_TypeDef *spi_port;
 } sdcard_config_t;
 
 typedef struct {

--- a/Drivers/SDCard/Src/sdcard.c
+++ b/Drivers/SDCard/Src/sdcard.c
@@ -35,8 +35,7 @@ error_type_t sdcardInit(sdcard_t *sdcard_object) {
     {
         return SYSTEM_NULL_PARAMETER;
     }
-  /* SPI1 parameter configuration*/
-    MX_FATFS_Init();
+
     return SYSTEM_OK;
 }
 

--- a/Drivers/SDCard/Src/sdcard.c
+++ b/Drivers/SDCard/Src/sdcard.c
@@ -7,10 +7,7 @@
 sdcard_t *sdcard_object;
 
 struct sdcard_t {
-    SPI_HandleTypeDef *spi_handle;
-    GPIO_TypeDef *cs_port;
-    uint16_t cs_pin;
-    SPI_TypeDef *spi_port;
+    SPI_HandleTypeDef* spi_handle;
     bool initialized;
 };
 
@@ -28,9 +25,6 @@ struct sdcard_t {
     }
 
    sdcard_object->spi_handle = config->spi_handle;
-   sdcard_object->cs_pin = config->cs_pin;
-   sdcard_object->cs_port = config->cs_port;
-   sdcard_object->spi_port = config->spi_port;
    sdcard_object->initialized = false;
 
    return sdcard_object;
@@ -41,62 +35,7 @@ error_type_t sdcardInit(sdcard_t *sdcard_object) {
     {
         return SYSTEM_NULL_PARAMETER;
     }
-
-    if (sdcard_object->cs_port == GPIOA)
-    {
-        __HAL_RCC_GPIOA_CLK_ENABLE();
-    }
-    else if (sdcard_object->cs_port == GPIOB)
-    {
-        __HAL_RCC_GPIOB_CLK_ENABLE();
-    }
-    else if (sdcard_object->cs_port == GPIOC)
-    {
-        __HAL_RCC_GPIOC_CLK_ENABLE();
-    }
-    else if (sdcard_object->cs_port == GPIOD)
-    {
-        __HAL_RCC_GPIOD_CLK_ENABLE();
-    }
-    else if (sdcard_object->cs_port == GPIOE)
-    {
-        __HAL_RCC_GPIOE_CLK_ENABLE();
-    }
-    else if (sdcard_object->cs_port == GPIOH)
-    {
-        __HAL_RCC_GPIOH_CLK_ENABLE();
-    }
-    else
-    {
-        return SYSTEM_INVALID_PIN_PORT;
-    }
-
-    GPIO_InitTypeDef GPIO_InitStruct = {0};
-
-    GPIO_InitStruct.Pin = sdcard_object->cs_pin;
-    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_OD;
-    GPIO_InitStruct.Pull = GPIO_PULLUP;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_MEDIUM;
-    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-    HAL_GPIO_WritePin(sdcard_object->cs_port, sdcard_object->cs_pin, GPIO_PIN_SET);
   /* SPI1 parameter configuration*/
-  sdcard_object->spi_handle->Instance = sdcard_object->spi_port;
-  sdcard_object->spi_handle->Init.Mode = SPI_MODE_MASTER;
-  sdcard_object->spi_handle->Init.Direction = SPI_DIRECTION_2LINES;
-  sdcard_object->spi_handle->Init.DataSize = SPI_DATASIZE_8BIT;
-  sdcard_object->spi_handle->Init.CLKPolarity = SPI_POLARITY_LOW;
-  sdcard_object->spi_handle->Init.CLKPhase = SPI_PHASE_1EDGE;
-  sdcard_object->spi_handle->Init.NSS = SPI_NSS_SOFT;
-  sdcard_object->spi_handle->Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256;
-  sdcard_object->spi_handle->Init.FirstBit = SPI_FIRSTBIT_MSB;
-  sdcard_object->spi_handle->Init.TIMode = SPI_TIMODE_DISABLE;
-  sdcard_object->spi_handle->Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
-  sdcard_object->spi_handle->Init.CRCPolynomial = 10;
-  if (HAL_SPI_Init(sdcard_object->spi_handle) != HAL_OK)
-  {
-    Error_Handler();
-    return SYSTEM_FAILED;
-  }
     MX_FATFS_Init();
     return SYSTEM_OK;
 }

--- a/Drivers/SDCard/Src/sdcard_example.c
+++ b/Drivers/SDCard/Src/sdcard_example.c
@@ -7,9 +7,6 @@ void example()
     /* Initialize the SD card */
   sdcard_config_t sdcard_config = {
     .spi_handle = &hspi1,
-    .cs_port = SD_CS_GPIO_Port, // Set your GPIO port and pin for chip select
-    .cs_pin = SD_CS_Pin,
-    .spi_port = SPI1
   };
 //Create the object
   sdcard_t *sdcard_object = sdcard_create(&sdcard_config);

--- a/Drivers/SDCard/Src/sdcard_example.c
+++ b/Drivers/SDCard/Src/sdcard_example.c
@@ -4,12 +4,12 @@
 
 void example()
 {
-    /* Initialize the SD card */
-  sdcard_config_t sdcard_config = {
+   sdcard_config_t sdcard_config = {
     .spi_handle = &hspi1,
+   
   };
 //Create the object
-  sdcard_t *sdcard_object = sdcard_create(&sdcard_config);
+  sdcard_t *sdcard_object = sdcardCreate(&sdcard_config);
   if (!sdcard_object) {
     printf("Failed to configure SD card instance\n");
     exit(1);
@@ -33,7 +33,7 @@ void example()
 
   // Get SD card information
   sdcard_info_t sdcard_info;
-  error_type_t result = sdcardGetInfo(&fs, &sdcard_info);
+  error_type_t result = sdcardGetInfo(sdcard_object,&fs, &sdcard_info);
   if (result != SYSTEM_OK) {
     printf("Failed to get SD card information\n");
     exit(1);
@@ -107,6 +107,4 @@ void example()
 
     // Unmount the SD card
   f_mount(NULL, "", 0);
-
-
 }


### PR DESCRIPTION
Make drivers use full dependency injection instead of creating their object internally. This will make drivers easier and accept lesser number of parameters. And most importantly allow HAL objects to be shared among different drivers.